### PR TITLE
For AWS S3 plugin, we always use original name

### DIFF
--- a/sceditor/classes/lhbbcode/lhbbcode.php
+++ b/sceditor/classes/lhbbcode/lhbbcode.php
@@ -329,7 +329,7 @@ class erLhcoreClassBBCode
    				$file = erLhcoreClassModelChatFile::fetch($fileID);
 
    				// Check that user has permission to see the chat. Let say if user purposely types file bbcode
-   				if ($hash == md5($file->name.'_'.$file->chat_id)) {
+   				if ($hash == $file->security_hash) {
    					return "<a href=\"" . erLhcoreClassDesign::baseurl('file/downloadfile')."/{$file->id}/{$hash}\" class=\"link\" >" . erTranslationClassLhTranslation::getInstance()->getTranslation('file/file','Download file').' - '.htmlspecialchars($file->upload_name).' ['.$file->extension.']' . "</a>";
    				}
    			} catch (Exception $e) {


### PR DESCRIPTION
I found another issue after last fix that I can NOT download a file from the file_url, cause there are several places need to check the $file->security_hash, and each of them should be updated.

It's up to the erLhcoreClassModelChatFile Class to make rule of the security_hash, every other just get the it for checking permission.

Please check it, thanks!